### PR TITLE
GEOMESA-311 Handle 'attr1 and attr2' filters

### DIFF
--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/AttributeIdxStrategy.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/AttributeIdxStrategy.scala
@@ -136,6 +136,18 @@ trait AttributeIdxStrategy extends Strategy with Logging {
                     s"${one.getClass.getName}, ${two.getClass.getName}"
         throw new RuntimeException(msg)
     }
+
+  def partitionFilter(filter: Filter, sft: SimpleFeatureType): (Query, Filter) = {
+
+    val (indexFilter, cqlFilter) = filter match {
+      case and: And =>
+        pickout(AttributeIndexStrategy.getAttributeIndexStrategy(_, sft).isDefined)(and.getChildren)
+      case f: Filter =>
+        (Some(f), Seq())
+    }
+
+    (new Query(sft.getTypeName, filterListAsAnd(cqlFilter).getOrElse(Filter.INCLUDE)), indexFilter.get)
+  }
 }
 
 class AttributeIdxEqualsStrategy extends AttributeIdxStrategy {

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/FilterHelper.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/FilterHelper.scala
@@ -148,4 +148,14 @@ object FilterHelper {
     case Nil => None
     case _ => Some(ff.and(filters))
   }
+
+  def pickout(pred: Filter => Boolean)(s: Seq[Filter]): (Option[Filter], Seq[Filter]) =
+    if (s.isEmpty) (None, s) else {
+      val h = s.head
+      val t = s.tail
+      if (pred(h)) (Some(h), t) else {
+        val (x, xs) = pickout(pred)(t)
+        (x, h +: xs)
+      }
+    }
 }

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/QueryStrategyDecider.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/QueryStrategyDecider.scala
@@ -19,7 +19,7 @@ package org.locationtech.geomesa.core.index
 import org.geotools.data.Query
 import org.locationtech.geomesa.core.index.QueryHints._
 import org.opengis.feature.simple.SimpleFeatureType
-import org.opengis.filter._
+import org.opengis.filter.{Id, And, PropertyIsLike}
 
 import scala.collection.JavaConversions._
 
@@ -42,7 +42,7 @@ object QueryStrategyDecider {
       new STIdxStrategy
     } else {
       // check if we can use the attribute index first
-      val attributeStrategy = getAttributeIndexStrategy(filter, sft)
+      val attributeStrategy = AttributeIndexStrategy.getAttributeIndexStrategy(filter, sft)
       attributeStrategy.getOrElse {
         filter match {
           case idFilter: Id => new RecordIdxStrategy


### PR DESCRIPTION
If multiple attribute filters are indexable, use the first one
In the future, a query optimizer will make more informed decision
