### PR TITLE
Add more JsonPath parsing tests

### DIFF
--- a/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathFilterFunctionTest.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathFilterFunctionTest.scala
@@ -24,20 +24,36 @@ class JsonPathFilterFunctionTest extends Specification {
       |   "foo" : "bar",
       |   "foo.foo" : "bar",
       |   "foo foo" : "bar",
+      |   "foo_foo" : "bar",
       |   "bar" : {
       |     "boo" : "hiss",
       |     "boo.boo" : "hiss",
-      |     "boo boo" : "hiss"
+      |     "boo boo" : "hiss",
+      |     "boo_boo" : "hiss",
       |     },
       |   "bar.bar" : {
       |     "boo" : "hiss",
       |     "boo.boo" : "hiss",
-      |     "boo boo" : "hiss"
+      |     "boo boo" : "hiss",
+      |     "boo_boo" : "hiss",
       |     },
       |   "bar bar" : {
       |     "boo" : "hiss",
       |     "boo.boo" : "hiss",
-      |     "boo boo" : "hiss"
+      |     "boo boo" : "hiss",
+      |     "boo_boo" : "hiss",
+      |     },
+      |   "bar_bar" : {
+      |     "boo" : "hiss",
+      |     "boo.boo" : "hiss",
+      |     "boo boo" : "hiss",
+      |     "boo_boo" : "hiss",
+      |     },
+      |   "bar (bar)" : {
+      |     "boo (boo)" : "hiss",
+      |     },
+      |   "bar(bar)" : {
+      |     "boo(boo)" : "hiss",
       |     },
       | }
     """.stripMargin
@@ -46,52 +62,162 @@ class JsonPathFilterFunctionTest extends Specification {
   sf.setAttribute(0, json)
 
   "Json Attr Function" should {
+    "not parse invalid paths" in {
+		  ECQL.toFilter("jsonPath('$.json.foo.foo') = 'bar'").evaluate(sf) must beFalse
+		  ECQL.toFilter("jsonPath('$.json.foo foo') = 'bar'").evaluate(sf) must throwA[RuntimeException]
+    }
     "extract root attribute from json" in {
       ECQL.toFilter("jsonPath('$.json.foo') = 'bar'").evaluate(sf) must beTrue
     }
 
     "extract root attribute with period from json" in {
       ECQL.toFilter("jsonPath('$.json.[''foo.foo'']') = 'bar'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''foo.foo'']') = 'bar'").evaluate(sf) must beTrue
     }
 
     "extract root attribute with space from json" in {
       ECQL.toFilter("jsonPath('$.json.[''foo foo'']') = 'bar'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''foo foo'']') = 'bar'").evaluate(sf) must beTrue
+    }
+
+    "extract root attribute with underscore from json" in {
+      ECQL.toFilter("jsonPath('$.json.[''foo_foo'']') = 'bar'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''foo_foo'']') = 'bar'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.foo_foo') = 'bar'").evaluate(sf) must beTrue
     }
 
     "extract sub attribute from json" in {
       ECQL.toFilter("jsonPath('$.json.bar.boo') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar.[''boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar[''boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar''].boo') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar''].[''boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar''][''boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar''].boo') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar''].[''boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar''][''boo'']') = 'hiss'").evaluate(sf) must beTrue
     }
 
     "extract sub attribute from json with period in sub attribute name" in {
       ECQL.toFilter("jsonPath('$.json.bar.[''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar[''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
     }
 
     "extract sub attribute from json with space in sub attribute name" in {
       ECQL.toFilter("jsonPath('$.json.bar.[''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar[''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with underscore in sub attribute name" in {
+      ECQL.toFilter("jsonPath('$.json.bar.[''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar[''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar.boo_boo') = 'hiss'").evaluate(sf) must beTrue
     }
 
     "extract sub attribute from json with period in attribute name" in {
       ECQL.toFilter("jsonPath('$.json.[''bar.bar''].boo') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar.bar''].boo') = 'hiss'").evaluate(sf) must beTrue
     }
 
-    "extract sub attribute from json with period in attribute and sub attribute name" in {
+    "extract sub attribute from json with period in attribute and period in sub attribute name" in {
       ECQL.toFilter("jsonPath('$.json.[''bar.bar''].[''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar.bar''][''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar.bar''].[''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar.bar''][''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
     }
 
     "extract sub attribute from json with period in attribute and space in sub attribute name" in {
       ECQL.toFilter("jsonPath('$.json.[''bar.bar''].[''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar.bar''][''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar.bar''].[''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar.bar''][''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with period in attribute and underscore in sub attribute name" in {
+      ECQL.toFilter("jsonPath('$.json.[''bar.bar''].[''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar.bar''][''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar.bar''].boo_boo') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar.bar''].[''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar.bar''][''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar.bar''].boo_boo') = 'hiss'").evaluate(sf) must beTrue
     }
 
     "extract sub attribute from json with space in attribute name" in {
       ECQL.toFilter("jsonPath('$.json.[''bar bar''].boo') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar bar''].boo') = 'hiss'").evaluate(sf) must beTrue
     }
 
     "extract sub attribute from json with space in attribute and period in sub attribute name" in {
       ECQL.toFilter("jsonPath('$.json.[''bar bar''].[''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar bar''][''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar bar''].[''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar bar''][''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
     }
 
     "extract sub attribute from json with space in attribute and space in sub attribute name" in {
       ECQL.toFilter("jsonPath('$.json.[''bar bar''].[''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar bar''][''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar bar''].[''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar bar''][''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with space in attribute and underscore in sub attribute name" in {
+      ECQL.toFilter("jsonPath('$.json.[''bar bar''].[''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar bar''][''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar bar''].boo_boo') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar bar''].[''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar bar''][''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar bar''].boo_boo') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with underscore in attribute name" in {
+      ECQL.toFilter("jsonPath('$.json.[''bar_bar''].boo') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar_bar''].boo') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar_bar.boo') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with underscore in attribute and period in sub attribute name" in {
+      ECQL.toFilter("jsonPath('$.json.[''bar_bar''].[''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar_bar''][''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar_bar''].[''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar_bar''][''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar_bar.[''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar_bar[''boo.boo'']') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with underscore in attribute and space in sub attribute name" in {
+      ECQL.toFilter("jsonPath('$.json.[''bar_bar''].[''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar_bar''][''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar_bar''].[''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar_bar''][''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar_bar.[''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar_bar[''boo boo'']') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with underscore in attribute and underscore in sub attribute name" in {
+      ECQL.toFilter("jsonPath('$.json.[''bar_bar''].[''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar_bar''][''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar_bar''].boo_boo') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar_bar''].[''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar_bar''][''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar_bar''].boo_boo') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar_bar.[''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar_bar[''boo_boo'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.bar_bar.boo_boo') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with space and round brackets in attribute and space and round brackets in sub attribute name" in {
+      ECQL.toFilter("jsonPath('$.json.[''bar (bar)''].[''boo (boo)'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar (bar)''][''boo (boo)'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar (bar)''].[''boo (boo)'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar (bar)''][''boo (boo)'']') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with round brackets in attribute and round brackets in sub attribute name" in {
+      ECQL.toFilter("jsonPath('$.json.[''bar(bar)''].[''boo(boo)'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json.[''bar(bar)''][''boo(boo)'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar(bar)''].[''boo(boo)'']') = 'hiss'").evaluate(sf) must beTrue
+      ECQL.toFilter("jsonPath('$.json[''bar(bar)''][''boo(boo)'']') = 'hiss'").evaluate(sf) must beTrue
     }
   }
 }

--- a/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathParserTest.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathParserTest.scala
@@ -20,6 +20,7 @@ class JsonPathParserTest extends Specification {
   "JsonPathParser" should {
     "not parse invalid paths" in {
       JsonPathParser.parse("$.$") must throwA[ParsingException]
+      JsonPathParser.parse("$.foo foo") must throwA[ParsingException]
     }
     "correctly parse attribute paths" in {
       val path = JsonPathParser.parse("$.foo")


### PR DESCRIPTION
Adds more tests for jsonPath parsing.

Specifically, it verifies that with the from the jsonPath filter, you can query paths with special characters using different notations.

E.g. given a JSON object:
```js
{
  "foo": "bar",
  "foo foo": "bar bar",
  "foo_foo": "bar_bar",
  "foo (foo)": "bar (bar)",
  "foo(foo)": "bar(bar)",
}
```
...you can access these paths as follows:
```js
jsonPath('$.[''foo'']') = 'bar'
jsonPath('$[''foo'']') = 'bar'
jsonPath('$.foo') = 'bar'

jsonPath('$.[''foo foo'']') = 'bar bar'
jsonPath('$[''foo foo'']') = 'bar bar'

jsonPath('$.[''foo_foo'']') = 'bar_bar'
jsonPath('$[''foo_foo'']') = 'bar_bar'
jsonPath('$.foo_foo') = 'bar_bar'

jsonPath('$.[''foo (foo)'']') = 'bar (bar)'
jsonPath('$[''foo (foo)'']') = 'bar (bar)'

jsonPath('$.[''foo(foo)'']') = 'bar(bar)'
jsonPath('$[''foo(foo)'']') = 'bar(bar)'
jsonPath('$.foo(foo)') = 'bar(bar)'
```
